### PR TITLE
Improvements proposal

### DIFF
--- a/lib/Validator/LIVR.php
+++ b/lib/Validator/LIVR.php
@@ -11,15 +11,15 @@ class LIVR
      */
     const VERSION = '2.0.0';
 
-    private $isPrepared        = false;
-    private $livrRules         = array();
-    private $validators        = array();
-    private $validatorBuilders = array();
-    private $errors            = false;
-    private $isAutoTrim        = false;
+    protected $isPrepared        = false;
+    protected $livrRules         = array();
+    protected $validators        = array();
+    protected $validatorBuilders = array();
+    protected $errors            = false;
+    protected $isAutoTrim        = false;
 
-    private static $IS_DEFAULT_AUTO_TRIM = 0;
-    private static $DEFAULT_RULES = array(
+    protected static $IS_DEFAULT_AUTO_TRIM = 0;
+    protected static $DEFAULT_RULES = array(
         'required'                  => 'Validator\LIVR\Rules\Common::required',
         'not_empty'                 => 'Validator\LIVR\Rules\Common::notEmpty',
         'not_empty_list'            => 'Validator\LIVR\Rules\Common::notEmptyList',
@@ -127,7 +127,7 @@ class LIVR
     }
 
 
-    public function validate($data)
+    public function validate($data, $context = null)
     {
         if (!$this->isPrepared) {
             $this->prepare();
@@ -161,7 +161,8 @@ class LIVR
                 $errCode = $vCb(
                     ( array_key_exists($fieldName, $result) ? $result[$fieldName] : $value ),
                     $data,
-                    $fieldResult
+                    $fieldResult,
+                    $context
                 );
 
                 if ($errCode) {
@@ -214,7 +215,7 @@ class LIVR
         return $this->validatorBuilders;
     }
 
-    private function parseRule($livrRule)
+    protected function parseRule($livrRule)
     {
         if (\Validator\LIVR\Util::isAssocArray($livrRule)) {
             reset($livrRule);
@@ -234,7 +235,7 @@ class LIVR
     }
 
 
-    private function buildValidator($name, $args)
+    protected function buildValidator($name, $args)
     {
         if (!array_key_exists($name, $this->validatorBuilders)) {
             throw new \Exception("Rule [$name] not registered");
@@ -246,7 +247,7 @@ class LIVR
         return call_user_func_array($this->validatorBuilders[$name], $funcArgs);
     }
 
-    private static function buildAliasedRule($alias)
+    protected static function buildAliasedRule($alias)
     {
         if (!$alias['name']) {
             throw new \Exception("Alias name required");
@@ -259,8 +260,8 @@ class LIVR
             $validator = new \Validator\LIVR(array('value' => $alias['rules']));
             $validator->registerRules($ruleBuilders)->prepare();
 
-            return function ($value, $params, &$outputArr) use ($validator, $alias) {
-                $result = $validator->validate(array('value' => $value));
+            return function ($value, $params, &$outputArr, $context = null) use ($validator, $alias) {
+                $result = $validator->validate(array('value' => $value), $context);
 
                 if ($result) {
                     $outputArr = $result['value'];
@@ -273,7 +274,7 @@ class LIVR
         };
     }
 
-    private function autoTrim($data)
+    protected function autoTrim($data)
     {
         if (is_string($data)) {
             return trim($data);

--- a/lib/Validator/LIVR/Rules/Meta.php
+++ b/lib/Validator/LIVR/Rules/Meta.php
@@ -9,7 +9,7 @@ class Meta
         $validator = new \Validator\LIVR($livr);
         $validator->registerRules($ruleBuilders)->prepare();
 
-        return function ($nestedObject, $params, &$outputArr) use ($validator) {
+        return function ($nestedObject, $params, &$outputArr, $context = null) use ($validator) {
             if (!isset($nestedObject) || $nestedObject === '') {
                 return;
             }
@@ -18,7 +18,7 @@ class Meta
                 return 'FORMAT_ERROR';
             }
 
-            $result = $validator->validate($nestedObject);
+            $result = $validator->validate($nestedObject, $context);
 
             if ($result !== false && $result !== null) {
                 $outputArr = $result;
@@ -44,7 +44,7 @@ class Meta
         $validator = new \Validator\LIVR(array('field' => $livr));
         $validator->registerRules($ruleBuilders)->prepare();
 
-        return function ($values, $params, &$outputArr) use ($validator) {
+        return function ($values, $params, &$outputArr, $context = null) use ($validator) {
             if (!isset($values) || $values === '') {
                 return;
             }
@@ -58,7 +58,7 @@ class Meta
             $hasErrors = false;
 
             foreach ($values as $value) {
-                $result = $validator->validate(array('field' => $value));
+                $result = $validator->validate(array('field' => $value), $context);
 
                 if ($result) {
                     $results[] = $result['field'];
@@ -85,7 +85,7 @@ class Meta
         $validator = new \Validator\LIVR($livr);
         $validator->registerRules($ruleBuilders)->prepare();
 
-        return function ($objects, $params, &$outputArr) use ($validator) {
+        return function ($objects, $params, &$outputArr, $context = null) use ($validator) {
             if (!isset($objects) || $objects ==='') {
                 return;
             }
@@ -99,7 +99,7 @@ class Meta
             $hasErrors = false;
 
             foreach ($objects as $object) {
-                $result = $validator->validate($object);
+                $result = $validator->validate($object, $context);
 
                 if ($result !== false && $result !== null) {
                     $errors[] = null;
@@ -130,7 +130,7 @@ class Meta
             $validators[$selectorValue] = $validator;
         }
 
-        return function ($objects, $params, &$outputArr) use ($validators, $selectorField) {
+        return function ($objects, $params, &$outputArr, $context = null) use ($validators, $selectorField) {
             $results   = array();
             $errors    = array();
             $hasErrors = false;
@@ -145,7 +145,7 @@ class Meta
                 }
 
                 $validator = $validators[ $object[$selectorField] ];
-                $result = $validator->validate($object);
+                $result = $validator->validate($object, $context);
 
                 if ($result) {
                     $results[] = $result;
@@ -175,7 +175,7 @@ class Meta
             $validators[$selectorValue] = $validator;
         }
 
-        return function ($object, $params, &$outputArr) use ($validators, $selectorField) {
+        return function ($object, $params, &$outputArr, $context = null) use ($validators, $selectorField) {
             if (!isset($object) || $object === '') {
                 return '';
             }
@@ -187,7 +187,7 @@ class Meta
             }
 
             $validator = $validators[ $object[$selectorField] ];
-            $result = $validator->validate($object);
+            $result = $validator->validate($object, $context);
 
             if ($result !== false && $result !== null) {
                 $outputArr = $result;
@@ -218,14 +218,14 @@ class Meta
             $validators[] = $validator;
         }
 
-        return function ($value, $params, &$outputArr) use ($validators) {
+        return function ($value, $params, &$outputArr, $context = null) use ($validators) {
             if (!isset($value) || $value === '') {
                 return;
             }
 
             $lastError = null;
             foreach ($validators as $validator) {
-                $result = $validator->validate(array('field' => $value));
+                $result = $validator->validate(array('field' => $value), $context);
 
                 if ($result !== false && $result !== null) {
                     $outputArr = $result['field'];


### PR DESCRIPTION
- Make all LIVR methods `protected` to allow easier integration/adaptation.
- Add support for a special but optional `$context` argument in all validators that can be any type and allows to pass custom data that validators can use.

:arrow_forward: This PR should not introduce any BC-break